### PR TITLE
Model fidelity: wire up retirement income; 2026 tax law

### DIFF
--- a/models/personal_finance.py
+++ b/models/personal_finance.py
@@ -166,7 +166,8 @@ class PersonalFinanceModel:
         cumulative_inflation = np.cumprod(1 + self.inflation, axis=1)
         real_market_returns = (1 + self.market_returns) / (1 + self.inflation) - 1
 
-        self.income = np.maximum(self.income / cumulative_inflation, self.min_income)
+        self.income = self.income / cumulative_inflation
+        self.apply_income_floor()
 
         self.initialize_simulation()
 
@@ -306,13 +307,27 @@ class PersonalFinanceModel:
 
         return annual_tax * years_left
 
+    def apply_income_floor(self):
+        # min_income is a reservation wage: it floors labor income during
+        # working years only, and must not resurrect wages for retirees
+        working_years = min(self.years_until_retirement, self.years)
+        self.income[:, :working_years] = np.maximum(
+            self.income[:, :working_years], self.min_income
+        )
+
     def calculate_total_income(self, t, current_age):
         base_income = self.income[:, t]
         self.pension_income[:, t] = self.calculate_pension_income(t, current_age)
 
         total_income = base_income + self.pension_income[:, t]
 
-        return np.maximum(total_income, self.min_income)
+        # Non-wage retirement income (annuities, part-time work modeled as
+        # a lump sum) — the app's "Retirement income" input, previously a
+        # silent no-op
+        if t >= self.years_until_retirement:
+            total_income = total_income + self.retirement_income
+
+        return total_income
 
     def calculate_retirement_withdrawal(
         self, t, current_age, total_real_income, consumption

--- a/models/personal_finance.py
+++ b/models/personal_finance.py
@@ -582,6 +582,13 @@ class PersonalFinanceModel:
         real_taxable_income = (
             total_real_income - real_contributions + real_withdrawals
         )
+        # At most 85% of US Social Security benefits are taxable; the
+        # provisional-income phase-in is not modeled, so this applies the
+        # upper bound. UK State Pension is fully taxable.
+        if self.tax_region != "UK":
+            real_taxable_income = (
+                real_taxable_income - 0.15 * self.pension_income[:, t]
+            )
         self.real_taxable_income[:, t] = real_taxable_income
 
         # Payroll taxes apply to labor income only, not pension income or

--- a/models/retirement_accounts.py
+++ b/models/retirement_accounts.py
@@ -17,18 +17,19 @@ class RetirementAccounts:
             raise ValueError(f"Unsupported region: {self.region}")
 
     def _initialize_uk_parameters(self):
-        self.pension_annual_allowance = 40000
-        self.lifetime_allowance = 1073100
+        # UK 2025/26; the lifetime allowance was abolished in 2024
+        self.pension_annual_allowance = 60000
 
     def _initialize_us_parameters(self):
-        self.traditional_401k_limit = 22500
-        self.roth_401k_limit = 22500
-        self.traditional_ira_limit = 6500
-        self.roth_ira_limit = 6500
+        # US 2026 limits; RMD age 73 per SECURE 2.0
+        self.traditional_401k_limit = 24500
+        self.roth_401k_limit = 24500
+        self.traditional_ira_limit = 7500
+        self.roth_ira_limit = 7500
         self.catchup_contribution_age = 50
-        self.catchup_401k = 7500
-        self.catchup_ira = 1000
-        self.rmd_age = 72
+        self.catchup_401k = 8000
+        self.catchup_ira = 1100
+        self.rmd_age = 73
 
     def calculate_contribution(self, income, age, contribution_rate):
         if self.region == "UK":

--- a/models/tax_system.py
+++ b/models/tax_system.py
@@ -4,12 +4,12 @@ import numpy as np
 class TaxSystem:
     """Tax math for one region.
 
-    All monetary thresholds are 2023 values and are treated as constant in
-    REAL terms: the simulation runs on inflation-adjusted dollars, and
-    since US federal brackets (and, roughly, the other thresholds) are
-    indexed to inflation, holding them fixed in real terms is the intended
-    approximation. When updating for a new tax year, replace the values
-    below wholesale.
+    Monetary thresholds are treated as constant in REAL terms: the
+    simulation runs on inflation-adjusted dollars, and since US federal
+    brackets (and, roughly, the other thresholds) are indexed to
+    inflation, holding them fixed in real terms is the intended
+    approximation. Each block below is commented with its tax-year
+    vintage; when refreshing, replace a block wholesale.
     """
 
     def __init__(self, region):
@@ -35,50 +35,58 @@ class TaxSystem:
             raise ValueError(f"Unsupported tax region: {self.region}")
 
     def _initialize_uk_parameters(self):
+        # UK 2025/26 tax year. The personal-allowance taper above 100k
+        # income is not modeled.
         self.personal_allowance = 12570.0
         self.basic_rate_threshold = 50270.0
-        self.higher_rate_threshold = 150000.0
-        self.additional_rate_threshold = 125140.0
+        self.higher_rate_threshold = 125140.0  # additional rate starts here
         self.basic_rate = 0.20
         self.higher_rate = 0.40
         self.additional_rate = 0.45
-        self.ni_primary_threshold = 9568.0
+        self.ni_primary_threshold = 12570.0
         self.ni_upper_earnings_limit = 50270.0
-        self.ni_basic_rate = 0.12
+        self.ni_basic_rate = 0.08
         self.ni_higher_rate = 0.02
-        self.capital_gains_allowance = 6000.0
-        self.capital_gains_basic_rate = 0.10
-        self.capital_gains_higher_rate = 0.20
-        self.uk_full_pension = 10600.0
+        self.capital_gains_allowance = 3000.0
+        self.capital_gains_basic_rate = 0.18
+        self.capital_gains_higher_rate = 0.24
+        self.uk_full_pension = 11973.0  # full new State Pension 2025/26
         self.uk_qualifying_years = 35.0
 
     def _initialize_us_parameters(self):
-        # Federal tax parameters (common for all US states)
+        # Federal parameters, 2026 tax year (single filer)
         self.federal_brackets = [
-            (0.0, 0.10), (9950.0, 0.12), (40525.0, 0.22),
-            (86375.0, 0.24), (164925.0, 0.32), (209425.0, 0.35),
-            (523600.0, 0.37)
+            (0.0, 0.10), (12400.0, 0.12), (50400.0, 0.22),
+            (105700.0, 0.24), (201775.0, 0.32), (256225.0, 0.35),
+            (640600.0, 0.37)
         ]
-        self.ss_wage_base = 142800.0
+        self.standard_deduction = 16100.0
+        self.ss_wage_base = 184500.0
         self.ss_rate = 0.062
         self.medicare_rate = 0.0145
         self.capital_gains_brackets = [
-            (0.0, 0.0), (40400.0, 0.15), (445850.0, 0.20)
+            (0.0, 0.0), (49450.0, 0.15), (545500.0, 0.20)
         ]
-        self.max_taxable_earnings = 160200.0
-        self.bend_points = [1115.0, 6721.0]
+        # Net capital losses offset at most this much ordinary income per
+        # year; carryforwards are not modeled
+        self.capital_loss_limit = 3000.0
+        self.max_taxable_earnings = 184500.0
+        self.bend_points = [1226.0, 7391.0]
         self.pia_factors = [0.9, 0.32, 0.15]
         self.fra = 67.0
-        # Maximum monthly SS benefit by claiming age (2023)
-        self.ss_max_monthly_benefit = {62: 2572.0, 67: 3627.0, 70: 4555.0}
+        # Maximum monthly SS benefit by claiming age (2026; 62/70 derived
+        # from 2025 values + COLA, approximate)
+        self.ss_max_monthly_benefit = {62: 2910.0, 67: 4152.0, 70: 5251.0}
         self.charitable_donation_limit = 0.60
 
     def _initialize_california_parameters(self):
+        # California 2025 tax year (single filer; latest published)
         self.ca_brackets = [
-            (0.0, 0.01), (8932.0, 0.02), (21175.0, 0.04),
-            (33421.0, 0.06), (46394.0, 0.08), (58634.0, 0.093),
-            (299508.0, 0.103), (359407.0, 0.113), (599012.0, 0.123)
+            (0.0, 0.01), (10756.0, 0.02), (25499.0, 0.04),
+            (40245.0, 0.06), (55866.0, 0.08), (70606.0, 0.093),
+            (360659.0, 0.103), (432787.0, 0.113), (721314.0, 0.123)
         ]
+        self.ca_standard_deduction = 5540.0
 
     def _initialize_massachusetts_parameters(self):
         self.ma_rate = 0.05  # Massachusetts has a flat income tax rate
@@ -113,25 +121,32 @@ class TaxSystem:
             return self._calculate_us_tax(income, capital_gains, charitable_donations, wage_income)
 
     def _calculate_us_tax(self, income, capital_gains, charitable_donations, wage_income):
-        # Calculate Adjusted Gross Income (AGI)
-        agi = income + capital_gains
+        # Net capital losses offset at most capital_loss_limit of ordinary
+        # income; gains above zero are taxed at LTCG rates
+        capped_gains = np.maximum(capital_gains, -self.capital_loss_limit)
+        loss_offset = np.minimum(capped_gains, 0.0)
+        positive_gains = np.maximum(capped_gains, 0.0)
+
+        agi = income + capped_gains
 
         # Limit charitable donations to 60% of AGI
-        deductible_donations = np.minimum(charitable_donations, agi * self.charitable_donation_limit)
-
-        # Ordinary income is taxed at federal ordinary brackets; capital
-        # gains are excluded from that base and taxed at the LTCG brackets
-        # STACKED on top of ordinary income (gains fill brackets starting
-        # where ordinary income ends). States tax gains as ordinary income.
-        ordinary_taxable = np.maximum(income - deductible_donations, 0)
-
-        federal_income_tax = self._calculate_bracketed_tax(ordinary_taxable, self.federal_brackets)
-        capital_gains_tax = self._calculate_bracketed_tax(
-            ordinary_taxable + capital_gains, self.capital_gains_brackets
-        ) - self._calculate_bracketed_tax(ordinary_taxable, self.capital_gains_brackets)
-        state_income_tax = self._calculate_state_tax(
-            np.maximum(ordinary_taxable + capital_gains, 0)
+        deductible_donations = np.minimum(
+            charitable_donations, np.maximum(agi, 0) * self.charitable_donation_limit
         )
+
+        # Ordinary income (after loss offset, donations, and the standard
+        # deduction) is taxed at federal ordinary brackets; capital gains
+        # are taxed at the LTCG brackets STACKED on top of ordinary income
+        # (gains fill brackets starting where ordinary income ends).
+        # States tax gains as ordinary income.
+        ordinary_base = np.maximum(income + loss_offset - deductible_donations, 0)
+        federal_taxable = np.maximum(ordinary_base - self.standard_deduction, 0)
+
+        federal_income_tax = self._calculate_bracketed_tax(federal_taxable, self.federal_brackets)
+        capital_gains_tax = self._calculate_bracketed_tax(
+            federal_taxable + positive_gains, self.capital_gains_brackets
+        ) - self._calculate_bracketed_tax(federal_taxable, self.capital_gains_brackets)
+        state_income_tax = self._calculate_state_tax(ordinary_base + positive_gains)
         ss_tax = np.minimum(wage_income, self.ss_wage_base) * self.ss_rate
         medicare_tax = wage_income * self.medicare_rate
 
@@ -154,7 +169,8 @@ class TaxSystem:
 
     def _calculate_state_tax(self, taxable_income):
         if self.region == "California":
-            return self._calculate_bracketed_tax(taxable_income, self.ca_brackets)
+            ca_taxable = np.maximum(taxable_income - self.ca_standard_deduction, 0)
+            return self._calculate_bracketed_tax(ca_taxable, self.ca_brackets)
         elif self.region == "Massachusetts":
             return taxable_income * self.ma_rate
         elif self.region == "New York":

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -176,6 +176,7 @@ class TestPersonalFinanceModel(unittest.TestCase):
     
     def test_simulate_year(self):
         self.model.initialize_simulation()
+        self.model.income = np.array([[100000.0, 102000.0]])
         real_market_returns = np.array([[0.05, 0.05]])
         self.model.simulate_year(0, real_market_returns)
         

--- a/tests/test_retirement_accounts.py
+++ b/tests/test_retirement_accounts.py
@@ -12,10 +12,12 @@ def test_rmd_before_rmd_age_is_zero():
     assert rmd[0] == 0.0
 
 
-def test_rmd_at_72_uses_remaining_horizon():
+def test_rmd_starts_at_73_secure_2_0():
     accounts = RetirementAccounts("California")
-    rmd = accounts.calculate_rmd(np.array([180000.0]), np.array([72]))
-    assert rmd[0] == pytest.approx(180000.0 / 18)
+    # SECURE 2.0 moved the RMD age to 73
+    assert accounts.calculate_rmd(np.array([180000.0]), np.array([72]))[0] == 0.0
+    rmd = accounts.calculate_rmd(np.array([180000.0]), np.array([73]))
+    assert rmd[0] == pytest.approx(180000.0 / 17)
 
 
 def test_rmd_at_and_beyond_90_is_finite_and_positive():
@@ -41,7 +43,7 @@ def test_us_401k_limit_applies():
     contribution = accounts.calculate_contribution(
         np.array([500000.0]), np.array([40]), 0.1
     )
-    assert contribution[0] == 22500.0
+    assert contribution[0] == 24500.0
 
 
 def test_us_catchup_after_50():
@@ -49,4 +51,4 @@ def test_us_catchup_after_50():
     contribution = accounts.calculate_contribution(
         np.array([500000.0]), np.array([55]), 0.1
     )
-    assert contribution[0] == 30000.0
+    assert contribution[0] == 32500.0

--- a/tests/test_retirement_income.py
+++ b/tests/test_retirement_income.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pytest
+
+from models.personal_finance import PersonalFinanceModel
+from tests.test_tax_flow import make_params
+
+
+def make_retiree_model(**overrides):
+    # retired from t=5 of a 10-year sim, min_income floor present
+    params = make_params(
+        m=1,
+        years=10,
+        years_until_retirement=5,
+        years_until_death=10,
+        retirement_income=40000,
+        min_income=30000,
+        claim_age=99,  # no SS within horizon; isolates retirement_income
+    )
+    params.update(overrides)
+    model = PersonalFinanceModel(params)
+    model.inflation = np.zeros((1, 10))
+    return model
+
+
+def test_min_income_floor_applies_to_working_years_only():
+    # the floor is a reservation wage; it must not resurrect labor income
+    # for retirees
+    model = make_retiree_model()
+    model.income = np.zeros((1, 10))
+    model.income[0, :5] = 20000.0  # below the 30k floor
+    model.apply_income_floor()
+    assert np.all(model.income[0, :5] == 30000.0)
+    assert np.all(model.income[0, 5:] == 0.0)
+
+
+def test_retirement_income_received_after_retirement():
+    model = make_retiree_model()
+    model.income = np.zeros((1, 10))
+    total = model.calculate_total_income(6, 36)
+    assert total[0] == pytest.approx(40000.0)
+
+
+def test_retirement_income_not_received_while_working():
+    model = make_retiree_model()
+    model.income = np.zeros((1, 10))
+    model.income[0, :5] = 100000.0
+    total = model.calculate_total_income(2, 32)
+    assert total[0] == pytest.approx(100000.0)
+
+
+def test_retirement_income_pays_no_payroll_tax():
+    # retirement income is ordinary income but not wages
+    model = make_retiree_model()
+    model.income = np.zeros((1, 10))
+    model.initialize_simulation()
+    model.simulate_year(6, np.zeros((1, 10)))
+    expected_tax = model.tax_system.calculate_tax(
+        model.real_taxable_income[:, 6],
+        np.array([0.0]),
+        np.array([0.0]),
+        wage_income=np.array([0.0]),
+    )
+    assert model.tax_paid[0, 6] == pytest.approx(expected_tax[0])

--- a/tests/test_social_security.py
+++ b/tests/test_social_security.py
@@ -49,11 +49,11 @@ def test_before_claim_age_is_zero():
 
 
 def test_exact_pia_all_three_bands():
-    # AIME 6666.67 (35y at 80k): 0.9*1115 + 0.32*(6666.67-1115) = 2780.03/mo
+    # AIME 6666.67 (35y at 80k) with 2026 bend points 1226/7391
     model = make_retired_model(35, 80000.0)
     benefit = model.calculate_us_social_security(37, np.array([67]))
     aime = 80000.0 * 35 / (35 * 12)
-    expected_monthly = 0.9 * 1115.0 + 0.32 * (aime - 1115.0)
+    expected_monthly = 0.9 * 1226.0 + 0.32 * (aime - 1226.0)
     assert benefit[0] == pytest.approx(expected_monthly * 12, abs=1.0)
 
 

--- a/tests/test_tax_flow.py
+++ b/tests/test_tax_flow.py
@@ -139,3 +139,12 @@ def test_capital_gains_taxed_in_year_earned():
     model_no_gains.initialize_simulation()
     model_no_gains.simulate_year(0, np.zeros((1, 3)))
     assert model.tax_paid[0, 0] > model_no_gains.tax_paid[0, 0]
+
+
+def test_only_85_pct_of_social_security_is_taxable():
+    # US SS benefits are at most 85% includable in taxable income
+    model = PersonalFinanceModel(make_params())
+    model.pension_income[:, 0] = 20000.0
+    model.calculate_after_tax_income(0, np.array([50000.0]))
+    # taxable = 50000 - 0.15 * 20000
+    assert model.real_taxable_income[0, 0] == pytest.approx(47000.0)

--- a/tests/test_tax_system.py
+++ b/tests/test_tax_system.py
@@ -9,20 +9,20 @@ from models.tax_system import TaxSystem
 
 def test_federal_tax_at_50k():
     tax = TaxSystem("Texas")
-    # 9950*0.10 + (40525-9950)*0.12 + (50000-40525)*0.22
-    expected = 995.0 + 30575.0 * 0.12 + 9475.0 * 0.22
+    # 2026 single brackets: 12400*0.10 + (50000-12400)*0.12
+    expected = 1240.0 + 37600.0 * 0.12
     result = tax._calculate_bracketed_tax(np.array([50000.0]), tax.federal_brackets)
     assert result[0] == pytest.approx(expected, abs=0.01)
 
 
 def test_federal_tax_top_bracket_marginal_rate():
     tax = TaxSystem("Texas")
-    at_600k = tax._calculate_bracketed_tax(np.array([600000.0]), tax.federal_brackets)
+    at_700k = tax._calculate_bracketed_tax(np.array([700000.0]), tax.federal_brackets)
     at_threshold = tax._calculate_bracketed_tax(
-        np.array([523600.0]), tax.federal_brackets
+        np.array([640600.0]), tax.federal_brackets
     )
-    assert at_600k[0] - at_threshold[0] == pytest.approx(
-        (600000 - 523600) * 0.37, abs=0.01
+    assert at_700k[0] - at_threshold[0] == pytest.approx(
+        (700000 - 640600) * 0.37, abs=0.01
     )
 
 
@@ -35,7 +35,8 @@ def test_zero_income_zero_tax():
 
 def test_texas_50k_no_state_tax():
     tax = TaxSystem("Texas")
-    federal = 995.0 + 30575.0 * 0.12 + 9475.0 * 0.22
+    # ordinary taxable = 50000 - 16100 standard deduction = 33900
+    federal = 1240.0 + (33900.0 - 12400.0) * 0.12
     ss = 50000.0 * 0.062
     medicare = 50000.0 * 0.0145
     result = tax.calculate_tax(np.array([50000.0]))
@@ -44,10 +45,12 @@ def test_texas_50k_no_state_tax():
 
 def test_ss_tax_capped_at_wage_base():
     tax = TaxSystem("Texas")
-    ss_at_cap = 142800.0 * 0.062
-    for income in [142800.0, 200000.0]:
+    ss_at_cap = 184500.0 * 0.062
+    for income in [184500.0, 250000.0]:
         total = tax.calculate_tax(np.array([income]))
-        federal = tax._calculate_bracketed_tax(np.array([income]), tax.federal_brackets)
+        federal = tax._calculate_bracketed_tax(
+            np.array([income - 16100.0]), tax.federal_brackets
+        )
         medicare = income * 0.0145
         assert total[0] - federal[0] - medicare == pytest.approx(ss_at_cap, abs=0.01)
 
@@ -65,16 +68,16 @@ def test_charitable_deduction_capped_at_60pct_agi():
 def test_uk_50k():
     tax = TaxSystem("UK")
     income_tax = (50000.0 - 12570.0) * 0.20
-    ni = (50000.0 - 9568.0) * 0.12
+    ni = (50000.0 - 12570.0) * 0.08
     result = tax.calculate_tax(np.array([50000.0]))
     assert result[0] == pytest.approx(income_tax + ni, abs=0.01)
 
 
 def test_uk_below_personal_allowance():
     tax = TaxSystem("UK")
+    # below both the personal allowance and the NI primary threshold
     result = tax.calculate_tax(np.array([10000.0]))
-    expected_ni = (10000.0 - 9568.0) * 0.12
-    assert result[0] == pytest.approx(expected_ni, abs=0.01)
+    assert result[0] == pytest.approx(0.0, abs=0.01)
 
 
 # Capital gains: excluded from ordinary brackets, LTCG stacked on top
@@ -113,5 +116,26 @@ def test_uk_no_ni_on_non_wage_income():
     tax = TaxSystem("UK")
     all_wages = tax.calculate_tax(np.array([50000.0]))
     no_wages = tax.calculate_tax(np.array([50000.0]), wage_income=np.array([0.0]))
-    ni = (50000.0 - 9568.0) * 0.12
+    ni = (50000.0 - 12570.0) * 0.08
     assert all_wages[0] - no_wages[0] == pytest.approx(ni, abs=0.01)
+
+
+# Standard deduction and capital-loss cap
+
+def test_standard_deduction_zeroes_low_income_federal_tax():
+    tax = TaxSystem("Texas")
+    # income at the deduction: only payroll taxes remain
+    result = tax.calculate_tax(np.array([16100.0]))
+    payroll = 16100.0 * (0.062 + 0.0145)
+    assert result[0] == pytest.approx(payroll, abs=0.01)
+
+
+def test_capital_losses_offset_at_most_3000():
+    tax = TaxSystem("Texas")
+    base = tax.calculate_tax(np.array([100000.0]), np.array([0.0]))
+    small_loss = tax.calculate_tax(np.array([100000.0]), np.array([-3000.0]))
+    huge_loss = tax.calculate_tax(np.array([100000.0]), np.array([-50000.0]))
+    # -50k must be treated exactly like -3k (no carryforward modeled)
+    assert huge_loss[0] == pytest.approx(small_loss[0], abs=0.01)
+    # and the offset saves tax at the 22% marginal rate
+    assert base[0] - small_loss[0] == pytest.approx(3000.0 * 0.22, abs=0.01)


### PR DESCRIPTION
## Summary

Follow-up to #3 — these two commits were pushed ~25 minutes after that PR was merged, so they never landed on main.

- **retirement_income wired up**: the app's "Retirement income" slider was stored and never read, while the `min_income` floor resurrected fully-taxed phantom wages for retirees. The floor now applies to working-year wages only; retirement income arrives as ordinary non-wage income (no payroll tax).
- **2026 tax law + fidelity**: federal/CA/SS/UK constants refreshed from 2021–2023 vintages (each block commented with its tax-year vintage), federal ($16,100) + CA ($5,540) standard deductions, $3k capital-loss cap, 85% max Social Security inclusion, 401k limit $24,500, RMD age 73 (SECURE 2.0), UK NI 8% / additional-rate boundary fixed to £125,140. Net effect: taxes fall ~15–20%, pensions rise.

## Test plan

- [x] 56 tests pass; exact-value tax tests recomputed by hand for 2026 law
- [x] Fixed-seed snapshot: taxes/pensions move in expected directions; working-year income unchanged by the floor fix
- [x] App verified end-to-end via streamlit AppTest (AGI scenario enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)